### PR TITLE
API simplification

### DIFF
--- a/src/main/java/io/radanalytics/operator/Entrypoint.java
+++ b/src/main/java/io/radanalytics/operator/Entrypoint.java
@@ -100,8 +100,10 @@ public class Entrypoint {
                     return;
                 }
 
-                Constructor<? extends AbstractOperator> constructor = ((Class<? extends AbstractOperator>)operatorClass).getConstructor(String.class, boolean.class, KubernetesClient.class);
-                final AbstractOperator operator = constructor.newInstance(namespace, isOpenShift, client);
+                final AbstractOperator operator = ((Class<? extends AbstractOperator>)operatorClass).newInstance();
+                operator.setClient(client);
+                operator.setNamespace(namespace);
+                operator.setOpenshift(isOpenShift);
                 CompletableFuture<Watch> future = operator.start().thenApply(res -> {
                     log.info("{} started in namespace {}", operator.getName(), namespace);
                     return res;
@@ -111,7 +113,7 @@ public class Entrypoint {
                     return null;
                 });
                 futures.add(future);
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            } catch (InstantiationException | IllegalAccessException e) {
                 e.printStackTrace();
             }
         });

--- a/src/main/java/io/radanalytics/operator/common/Operator.java
+++ b/src/main/java/io/radanalytics/operator/common/Operator.java
@@ -11,4 +11,5 @@ public @interface Operator {
     boolean enabled() default true;
     String forKind();
     String prefix();
+    Class<? extends EntityInfo> infoClass();
 }


### PR DESCRIPTION
No need to override so many methods in the child operators. The only
really mandatory are onAdd and onDelete. For this to work, we need to
have a type information in the annotation.

- [X] Breaking change (fix or feature that would cause existing functionality to change)

!!! this breaks the backward compatibility !!!