### PR TITLE
Change to @Operator annotation params

### DIFF
--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -54,8 +54,8 @@ public abstract class AbstractOperator<T extends EntityInfo> {
     private volatile Watch watch;
 
     public AbstractOperator() {
-        this.entityName = getClass().getAnnotation(Operator.class).forKind().toLowerCase();
-        this.infoClass = (Class<T>) getClass().getAnnotation(Operator.class).infoClass();
+        this.infoClass = (Class<T>) getClass().getAnnotation(Operator.class).forKind();
+        this.entityName = infoClass.getSimpleName().toLowerCase();
         this.isCrd = getClass().getAnnotation(Operator.class).crd() || "true".equals(System.getenv("CRD"));
         String wannabePrefix = getClass().getAnnotation(Operator.class).prefix();
         wannabePrefix = "".equals(wannabePrefix) ? getClass().getPackage().getName() : wannabePrefix;

--- a/src/main/java/io/radanalytics/operator/common/Operator.java
+++ b/src/main/java/io/radanalytics/operator/common/Operator.java
@@ -8,9 +8,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Operator {
-    boolean enabled() default true;
-    String forKind();
+    Class<? extends EntityInfo> forKind();
+    String named() default "";;
     String prefix() default "";
-    Class<? extends EntityInfo> infoClass();
+    boolean enabled() default true;
     boolean crd() default false;
 }


### PR DESCRIPTION
the name will be derived from the class name ('forKind' field) by default, but it can be set explicitly by 'named'

benefit=less params:
```java
@Operator(forKind = SparkCluster.class, prefix = "radanalytics.io")
```


!!! WARNING  this may and will break the clients !