### PR TITLE
EntityInfo (iface -> abstract class)

### DIFF
--- a/src/main/java/io/radanalytics/operator/common/EntityInfo.java
+++ b/src/main/java/io/radanalytics/operator/common/EntityInfo.java
@@ -1,7 +1,7 @@
 package io.radanalytics.operator.common;
 
 /**
- * Simple interface that captures the information about the object we are interested in in the Kubernetes cluster.
+ * Simple abstract class that captures the information about the object we are interested in in the Kubernetes cluster.
  * Field called 'name' is the only compulsory information and it represents the name of the configmap.
  *
  * By extending this class and adding new fields to it, you can create a rich configuration object. The structure
@@ -9,7 +9,14 @@ package io.radanalytics.operator.common;
  * 'T extends EntityInfo' conversions prepared in
  * {@link io.radanalytics.operator.resource.HasDataHelper#parseCM(Class, io.fabric8.kubernetes.api.model.ConfigMap)}.
  */
-public interface EntityInfo {
-    void setName(String name);
-    String getName();
+public abstract class EntityInfo {
+    protected String name;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 }


### PR DESCRIPTION
This is a breaking change! Instead of forcing the children classes of `EntityInfo` to override the getter and setter for name, the name is stored on this abstract class. This also means that name doesn't have to be present in the json schema for CR or CM.