### PR TITLE
CR operator: ability to recover CRDs after restart

### DIFF
--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -223,6 +223,9 @@ public abstract class AbstractOperator<T extends EntityInfo> {
     }
 
     private CustomResourceDefinition initCrds() {
+        final String newPrefix = prefix.substring(0, prefix.length() - 1);
+        CustomResourceDefinition crdToReturn;
+
         List<CustomResourceDefinition> crds = client.customResourceDefinitions()
                 .list()
                 .getItems()
@@ -230,26 +233,26 @@ public abstract class AbstractOperator<T extends EntityInfo> {
                 .filter(p -> this.entityName.equals(p.getSpec().getNames().getKind()))
                 .collect(Collectors.toList());
         if (!crds.isEmpty()) {
-            return crds.get(0);
+            crdToReturn = crds.get(0);
+        } else {
+            final String plural = this.entityName + "s";
+            crdToReturn = new CustomResourceDefinitionBuilder()
+                    .withApiVersion("apiextensions.k8s.io/v1beta1")
+                    .withNewMetadata().withName(plural + "." + newPrefix)
+                    .endMetadata()
+                    .withNewSpec().withNewNames().withKind(this.entityName).withPlural(plural).endNames()
+                    .withGroup(newPrefix)
+                    .withVersion("v1")
+                    .withScope("Namespaced")
+                    .endSpec()
+                    .build();
+            client.customResourceDefinitions().createOrReplace(crdToReturn);
         }
 
-        final String newPrefix = prefix.substring(0, prefix.length() - 1);
-        final String plural = this.entityName + "s";
-        CustomResourceDefinition crd = new CustomResourceDefinitionBuilder()
-                .withApiVersion("apiextensions.k8s.io/v1beta1")
-                .withNewMetadata().withName(plural + "." + newPrefix)
-                .endMetadata()
-                .withNewSpec().withNewNames().withKind(this.entityName).withPlural(plural).endNames()
-                .withGroup(newPrefix)
-                .withVersion("v1")
-                .withScope("Namespaced")
-                .endSpec()
-                .build();
-        client.customResourceDefinitions().createOrReplace(crd);
-
         // register the new crd for json serialization
-        io.fabric8.kubernetes.internal.KubernetesDeserializer.registerCustomKind(newPrefix + "/" + crd.getSpec().getVersion() + "#" + this.entityName, InfoClass.class);
-        return crd;
+        io.fabric8.kubernetes.internal.KubernetesDeserializer.registerCustomKind(newPrefix + "/" + crdToReturn.getSpec().getVersion() + "#" + this.entityName, InfoClass.class);
+
+        return crdToReturn;
     }
 
     public void stop() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Description
After restart CRD based operator doesn't register existing CRDs, this change should fix it.


## Related Issue
Fixes #22 


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in one box that applies: -->

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
