### PR TITLE
remove the toLowerCase calls on entityName

### DIFF
--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -297,7 +297,16 @@ public abstract class AbstractOperator<T extends EntityInfo> {
     }
 
     private void initInternals() {
-        entityName = (named != null && !named.isEmpty()) ? named.toLowerCase() : (entityName != null && !entityName.isEmpty()) ? this.entityName.toLowerCase() : (infoClass == null ? "" : infoClass.getSimpleName().toLowerCase());
+         // prefer "named" for the entity name, otherwise "entityName" and finally the converted class name.
+        if (named != null && !named.isEmpty()) {
+            entityName = named;
+        } else if (entityName != null && !entityName.isEmpty()) {
+            entityName = this.entityName;
+        } else if (infoClass != null) {
+            entityName = infoClass.getSimpleName();
+        } else {
+            entityName = "";
+        }
         isCrd = isCrd || "true".equals(System.getenv("CRD"));
         prefix = prefix == null || prefix.isEmpty() ? getClass().getPackage().getName() : prefix;
         prefix = prefix + (!prefix.endsWith("/") ? "/" : "");

--- a/src/main/java/io/radanalytics/operator/common/crd/CrdDeployer.java
+++ b/src/main/java/io/radanalytics/operator/common/crd/CrdDeployer.java
@@ -68,7 +68,8 @@ public class CrdDeployer {
     }
 
     private static CustomResourceDefinitionFluent.SpecNested<CustomResourceDefinitionBuilder> getCRDBuilder(String prefix, String entityName) {
-        final String plural = entityName + "s";
+        // plural name must be all lowercase otherwise fabric8 will barf
+        final String plural = (entityName + "s").toLowerCase();
         return new CustomResourceDefinitionBuilder()
                 .withApiVersion("apiextensions.k8s.io/v1beta1")
                 .withNewMetadata().withName(plural + "." + prefix)


### PR DESCRIPTION
This change facilitates concrete implementation entity names with mixed
case. In some circumstances the capitalization of an entity name affects
how it is rendered by client applications, this change will give
implementation authors more control of the names.

## Description
* remove the `toLowerCase` calls in `initInternals` of `AbstractOperator` class

## Related Issue
helps fix this issue, https://github.com/radanalyticsio/spark-operator/issues/179

## Types of changes

- [X ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Breaking change (fix or feature that would cause existing functionality to change)

this will probably break things that are depending on the entity names being all lower case, on the upside those issues can be fixed by specifying the operators names in the `@Operator` annotation.