### PR TITLE
add short names support to annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ By default the operator is based on `ConfigMaps`, if you want to create `CRD`-ba
 For the CRDs the:
 * `forKind` field represent the name of the `CRD` ('s' at the end for plural)
 * `prefix` field in the annotation represents the group
+* `shortNames` field is an array of strings representing the shortened name of the resource.
 * as for the version, currently the `v1` is created automatically, but one can also create the `CRD` on his own before running the operator and providing the `forKind` and `prefix` matches, operator will use the existing `CRD`
 
 #### Configuration

--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -52,6 +52,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
     // these fields can be directly set from languages that don't support annotations, like JS
     protected String entityName;
     protected String prefix;
+    protected String[] shortNames;
     protected Class<T> infoClass;
     protected boolean isCrd;
     protected boolean enabled = true;
@@ -73,6 +74,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
             this.isCrd = annotation.crd();
             this.enabled = annotation.enabled();
             this.prefix = annotation.prefix();
+            this.shortNames = annotation.shortNames();
         } else {
             log.info("Annotation on the operator class not found, falling back to direct field access.");
             log.info("If the initialization fails, it's probably due to the fact that some compulsory fields are missing.");
@@ -242,7 +244,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
         log.info("Starting {} for namespace {}", operatorName, namespace);
 
         if (isCrd) {
-            this.crd = CrdDeployer.initCrds(client, prefix, entityName, infoClass, isOpenshift);
+            this.crd = CrdDeployer.initCrds(client, prefix, entityName, shortNames, infoClass, isOpenshift);
         }
 
         // onInit() can be overriden in child operators

--- a/src/main/java/io/radanalytics/operator/common/Operator.java
+++ b/src/main/java/io/radanalytics/operator/common/Operator.java
@@ -11,6 +11,7 @@ public @interface Operator {
     Class<? extends EntityInfo> forKind();
     String named() default "";
     String prefix() default "";
+    String[] shortNames() default {};
     boolean enabled() default true;
     boolean crd() default false;
 }


### PR DESCRIPTION
This change plumbs through support for a `shortNames` argument in the
operator annotations. The argument supports an array of strings and will
convert them to lowercase before applying to kubernetes.

## Description
add support for `shortNames` array in the `@Operator` annotation.

## Related Issue
#30 


## Types of changes

- [X] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
