### PR TITLE
add support for plural name in annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ For the CRDs the:
 * `forKind` field represent the name of the `CRD` ('s' at the end for plural)
 * `prefix` field in the annotation represents the group
 * `shortNames` field is an array of strings representing the shortened name of the resource.
+* `pluralName` field is a string value representing the plural name for the resource.
 * as for the version, currently the `v1` is created automatically, but one can also create the `CRD` on his own before running the operator and providing the `forKind` and `prefix` matches, operator will use the existing `CRD`
 
 #### Configuration

--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -53,6 +53,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
     protected String entityName;
     protected String prefix;
     protected String[] shortNames;
+    protected String pluralName;
     protected Class<T> infoClass;
     protected boolean isCrd;
     protected boolean enabled = true;
@@ -75,6 +76,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
             this.enabled = annotation.enabled();
             this.prefix = annotation.prefix();
             this.shortNames = annotation.shortNames();
+            this.pluralName = annotation.pluralName();
         } else {
             log.info("Annotation on the operator class not found, falling back to direct field access.");
             log.info("If the initialization fails, it's probably due to the fact that some compulsory fields are missing.");
@@ -244,7 +246,13 @@ public abstract class AbstractOperator<T extends EntityInfo> {
         log.info("Starting {} for namespace {}", operatorName, namespace);
 
         if (isCrd) {
-            this.crd = CrdDeployer.initCrds(client, prefix, entityName, shortNames, infoClass, isOpenshift);
+            this.crd = CrdDeployer.initCrds(client,
+                                            prefix,
+                                            entityName,
+                                            shortNames,
+                                            pluralName,
+                                            infoClass,
+                                            isOpenshift);
         }
 
         // onInit() can be overriden in child operators

--- a/src/main/java/io/radanalytics/operator/common/Operator.java
+++ b/src/main/java/io/radanalytics/operator/common/Operator.java
@@ -12,6 +12,7 @@ public @interface Operator {
     String named() default "";
     String prefix() default "";
     String[] shortNames() default {};
+    String pluralName() default "";
     boolean enabled() default true;
     boolean crd() default false;
 }


### PR DESCRIPTION
## Description

This change adds the argument `pluralName` to the annotation. In cases
where the name is not specified it defaults to the original behavior of
adding an "s" to the end of the entity name.

## Related Issue

none

## Types of changes

- [X] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
