### PR TITLE
Simple e2e test against one concrete operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,8 @@ Desktop.ini
 /k8s-spark-operator.yaml
 /openshift-spark-operator.yaml
 
+spark-operator
+
 # oc cluster up
 openshift.local.clusterup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install: true
 script:
   - make javadoc
   - make build-travis
+  - make travis-e2e-use-case
 
 #deploy:
 #  provider: script

--- a/.travis/.travis.e2e-oc.sh
+++ b/.travis/.travis.e2e-oc.sh
@@ -7,7 +7,7 @@ MANIFEST_SUFIX=""
 KIND="SparkCluster"
 VERSION="v3.9.0"
 
-RUN=0 source "${DIR}/../spark-operator/.travis/.travis.prepare.openshift.sh"
+#RUN=0 source "${DIR}/../spark-operator/.travis/.travis.prepare.openshift.sh"
 source "${DIR}/../spark-operator/.travis/.travis.test-common.sh"
 
 run_tests() {
@@ -20,14 +20,35 @@ run_tests() {
   logs
 }
 
+prepare_operator() {
+    set -ex
+    LIBRARY_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')"
+    rm -rf ${DIR}/../spark-operator || true
+    pushd ${DIR}/..
+	git clone --depth=100 --branch master --recurse-submodules https://github.com/radanalyticsio/spark-operator.git
+    cd spark-operator
+
+    # checkout the latest release
+    GIT_TAG="$(git describe --abbrev=0 --tags)"
+	[[ "${GIT_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && git checkout "${GIT_TAG}"
+
+    # use the -SNAPSHOTed version of abstract operator
+	sed -i'' "s;\(<abstract-operator.version>\)\([^<]\+\);\1${LIBRARY_VERSION};g" pom.xml
+    make build
+    popd
+    set +ex
+}
+
 main() {
+  prepare_operator
+
   [ "$TRAVIS" == "true" ] && download_openshift
   [ "$TRAVIS" == "true" ] && setup_insecure_registry
   setup_manifest
 
   DIR="${DIR}/../spark-operator/.travis"
 
-  export total=5
+  export total=6
   export testIndex=0
   tear_down
   setup_testing_framework

--- a/.travis/.travis.e2e-oc.sh
+++ b/.travis/.travis.e2e-oc.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+DIR="${DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}"
+BIN="oc"
+CRD="1"
+MANIFEST_SUFIX=""
+KIND="SparkCluster"
+VERSION="v3.9.0"
+
+RUN=0 source "${DIR}/../spark-operator/.travis/.travis.prepare.openshift.sh"
+source "${DIR}/../spark-operator/.travis/.travis.test-common.sh"
+
+run_tests() {
+  testCreateCluster1 || errorLogs
+  testScaleCluster || errorLogs
+  testDeleteCluster || errorLogs
+  sleep 5
+
+  testMetricServer || errorLogs
+  logs
+}
+
+main() {
+  [ "$TRAVIS" == "true" ] && download_openshift
+  [ "$TRAVIS" == "true" ] && setup_insecure_registry
+  setup_manifest
+
+  DIR="${DIR}/../spark-operator/.travis"
+
+  export total=5
+  export testIndex=0
+  tear_down
+  setup_testing_framework
+  os::test::junit::declare_suite_start "operator/tests"
+  cluster_up
+  testCreateOperator || { oc get events; oc get pods; exit 1; }
+  export operator_pod=`oc get pod -l app.kubernetes.io/name=spark-operator -o='jsonpath="{.items[0].metadata.name}"' | sed 's/"//g'`
+  run_tests
+  os::test::junit::declare_suite_end
+  tear_down
+}
+
+main $@

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,6 @@ install-parent:
 .PHONY: travis-e2e-use-case
 travis-e2e-use-case:
 	echo -e "travis_fold:start:e2e\033[33;1mSimple integration test\033[0m"
-	- rm -rf spark-operator || true
-	git clone --depth=100 --branch master --recurse-submodules https://github.com/radanalyticsio/spark-operator.git
-	# checkout the latest release
-	[[ $(shell git -C spark-operator/ describe --abbrev=0 --tags) =~ ^[0-9]+\.[0-9]+\.[0-9]+$$ ]] && cd spark-operator && git checkout $(shell git -C spark-operator/ describe --abbrev=0 --tags)
-	# use the -SNAPSHOTed version of abstract operator
-	cd spark-operator && sed -i'' "s;\(<abstract-operator.version>\)\([^<]\+\);\1$(shell mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)');g" pom.xml && make build
 	./.travis/.travis.e2e-oc.sh
 	echo -e "\ntravis_fold:end:e2e\r"
 

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ install-parent:
 
 .PHONY: travis-e2e-use-case
 travis-e2e-use-case:
-	echo -e "travis_fold:start:e2e\033[33;1mSimple integration test\033[0m"
 	./.travis/.travis.e2e-oc.sh
-	echo -e "\ntravis_fold:end:e2e\r"
 
 .PHONY: build-travis
 build-travis: install-parent build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install-parent:
 
 .PHONY: travis-e2e-use-case
 travis-e2e-use-case:
-	./.travis/.travis.e2e-oc.sh
+	./.travis/.travis.e2e-oc.sh || echo -e "\n\nEnd-to-end scenario ended up with error"
 
 .PHONY: build-travis
 build-travis: install-parent build


### PR DESCRIPTION
There is a new task in the Makefile that does following:
* clones the spark operator repo
* checkouts the latest released version of it
* use the latest operator as the dependency and build the operator + the container image
* prepares and starts openshift
* runs very basic tests against that operator that was built by previous steps like if the operator can be deployed, if it reacts on `onAdd`, `onDelete` and `onModified` events, and also if it exposes the metrics

It's good enough as a fist shot. Although, there is a very high chance that the failure in this e2e test will go unnoticed, because in case of the failure, the travis is marked as green.

Further extension would be either travis checks (this requires enabling "GitHub Apps" - https://blog.travis-ci.com/2018-05-07-announcing-support-for-github-checks-api-on-travis-ci-com)

or adding a simple comment on existing PR, using curl and GH token