### PR TITLE
Make the CRD operation mode the default one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://travis-ci.org/jvm-operators/abstract-operator.svg?branch=master)](https://travis-ci.org/jvm-operators/abstract-operator)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-`{ConfigMap|CRD}`-based approach for lyfecycle management of various resources in Kubernetes and OpenShift. Using the Operator pattern, you can leverage the Kubernetes control loop and react on various events in the cluster.
+`{CRD|ConfigMap}`-based approach for lyfecycle management of various resources in Kubernetes and OpenShift. Using the Operator pattern, you can leverage the Kubernetes control loop and react on various events in the cluster. The idea of the operator patern is to encapsulate the operational knowledge into the abovementioned control loop and declarative approach.
 
 ## Example Implementations
 * [spark-operator](https://github.com/radanalyticsio/spark-operator) - Java operator for managing Apache Spark clusters and apps
@@ -39,20 +39,21 @@ class FooOperator extends AbstractOperator[FooInfo] {
 ```
 
 ### CRDs
-By default the operator is based on `ConfigMaps`, if you want to create `CRD`-based operator, add `crd=true` parameter in the `@Operator` annotation. This will try to create the custom resource definition from the `infoClass` if it's not already there and then it listens on the newly created, deleted or modified custom resources (CR) of the given type.
+By default the operator is based on `CustomResources`, if you want to create `ConfigMap`-based operator, add `crd=false` parameter in the `@Operator` annotation. The CRD mode will try to create the custom resource definition from the `infoClass` if it's not already there and then it listens on the newly created, deleted or modified custom resources (CR) of the given type.
 
 For the CRDs the:
 * `forKind` field represent the name of the `CRD` ('s' at the end for plural)
 * `prefix` field in the annotation represents the group
 * `shortNames` field is an array of strings representing the shortened name of the resource.
 * `pluralName` field is a string value representing the plural name for the resource.
+* `enabled` field is a boolean value (default is `true`), if disabled the operator is silenced
 * as for the version, currently the `v1` is created automatically, but one can also create the `CRD` on his own before running the operator and providing the `forKind` and `prefix` matches, operator will use the existing `CRD`
 
 #### Configuration
 You can configure the operator using some environmental variables. Here is the list:
 * `WATCH_NAMESPACE`, example values `myproject`, `foo,bar,baz`, `*` - what namespaces the operator should be watching for the events,
 default: same namespace where the operator is deployed
-* `CRD`, values `true/false` - config maps = `false`, custom resources = `true`, default: `false`
+* `CRD`, values `true/false` - config maps = `false`, custom resources = `true`, default: `true`
 * `COLORS`, values `true/false` - if `true` there will be colors used in the log file, default: `true`
 * `METRICS`, values `true/false` - whether start the simple http server that exposes internal metrics. These metrics are in the Prometheus compliant format and can be scraped by Prometheus; default: `false`
 * `METRICS_JVM`, values `true/false` - whether expose also internal JVM metrics such as heap usage, number of threads and similar; default: `false`

--- a/src/main/java/io/radanalytics/operator/Entrypoint.java
+++ b/src/main/java/io/radanalytics/operator/Entrypoint.java
@@ -256,7 +256,7 @@ public class Entrypoint {
                 OperatorConfig.OPERATOR_OPERATION_TIMEOUT_MS
         ));
         values.addAll(Arrays.asList(gitSha, version,
-                Optional.ofNullable(System.getenv().get("CRD")).orElse("false"),
+                Optional.ofNullable(System.getenv().get("CRD")).orElse("true"),
                 Optional.ofNullable(System.getenv().get("COLORS")).orElse("true"),
                 SAME_NAMESPACE.equals(config.getNamespaces().iterator().next()) ? client.getNamespace() : config.getNamespaces().toString(),
                 String.valueOf(config.isMetrics()),

--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -321,7 +321,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
         } else {
             entityName = "";
         }
-        isCrd = isCrd || "true".equals(System.getenv("CRD"));
+        isCrd = isCrd || !"false".equals(System.getenv("CRD"));
         prefix = prefix == null || prefix.isEmpty() ? getClass().getPackage().getName() : prefix;
         prefix = prefix + (!prefix.endsWith("/") ? "/" : "");
         operatorName = "'" + entityName + "' operator";

--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -321,7 +321,11 @@ public abstract class AbstractOperator<T extends EntityInfo> {
         } else {
             entityName = "";
         }
-        isCrd = isCrd || !"false".equals(System.getenv("CRD"));
+
+        // if CRD env variable is defined, it will override the annotation parameter
+        if (null != System.getenv("CRD")) {
+            isCrd = !"false".equals(System.getenv("CRD"));
+        }
         prefix = prefix == null || prefix.isEmpty() ? getClass().getPackage().getName() : prefix;
         prefix = prefix + (!prefix.endsWith("/") ? "/" : "");
         operatorName = "'" + entityName + "' operator";

--- a/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
+++ b/src/main/java/io/radanalytics/operator/common/AbstractOperator.java
@@ -315,7 +315,7 @@ public abstract class AbstractOperator<T extends EntityInfo> {
         if (named != null && !named.isEmpty()) {
             entityName = named;
         } else if (entityName != null && !entityName.isEmpty()) {
-            entityName = this.entityName;
+            // ok case
         } else if (infoClass != null) {
             entityName = infoClass.getSimpleName();
         } else {

--- a/src/main/java/io/radanalytics/operator/common/Operator.java
+++ b/src/main/java/io/radanalytics/operator/common/Operator.java
@@ -14,5 +14,5 @@ public @interface Operator {
     String[] shortNames() default {};
     String pluralName() default "";
     boolean enabled() default true;
-    boolean crd() default false;
+    boolean crd() default true;
 }

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -88,14 +88,17 @@
         </svg>
     </a>CRDs
     </h3>
-    <p>By default the operator is based on <code>ConfigMaps</code>, if you want to create <code>CRD</code>-based
-        operator, add <code>crd=true</code> parameter in the <code>@Operator</code> annotation. This will try to create
+    <p>By default the operator is based on <code>CustomResourceDefinitions</code>, if you want to create <code>ConfigMap</code>-based
+        operator, add <code>crd=false</code> parameter in the <code>@Operator</code> annotation. Custom Resource operation mode will try to create
         the custom resource definition from the <code>infoClass</code> if it's not already there and then it listens on
         the newly created, deleted or modified custom resources (CR) of the given type.</p>
     <p>For the CRDs the:</p>
     <ul>
         <li><code>forKind</code> field represent the name of the <code>CRD</code> ('s' at the end for plular)</li>
+        <li><code>pluralName</code> explicitly se the plural name of the CR</li>
         <li><code>prefix</code> field in the annotation represents the group</li>
+        <li><code>shortNames</code> short names that can be used instead of the long version (service -&gt; svc, namespace -&gt; ns, etc.)</li>
+        <li><code>enabled</code> by default it's enabled, but one may want to temporarily disable/silence the operator</li>
         <li>as for the version, currently the <code>v1</code> is created automatically, but one can also create the
             <code>CRD</code> on his own before running the operator and providing the <code>forKind</code> and <code>prefix</code>
             matches, operator will use the existing <code>CRD</code></li>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Description
If the `CRD` environment variable was empty, the default behavior was creating the watchers for config maps. This PR revers the logic, so that by default we create CR watchers. If user wants configmaps, he/she needs to explicitly specify `CRD=false`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in one box that applies: -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)
