### PR TITLE
Add another implicit field on EntityInfo for capturing the namespace

### DIFF
--- a/src/main/java/io/radanalytics/operator/common/CustomResourceWatcher.java
+++ b/src/main/java/io/radanalytics/operator/common/CustomResourceWatcher.java
@@ -83,6 +83,7 @@ public class CustomResourceWatcher<T extends EntityInfo> extends AbstractWatcher
 
     public static <T extends EntityInfo> T defaultConvert(Class<T> clazz, InfoClass info) {
         String name = info.getMetadata().getName();
+        String namespace = info.getMetadata().getName();
         ObjectMapper mapper = new ObjectMapper();
         T infoSpec = mapper.convertValue(info.getSpec(), clazz);
         if (infoSpec == null) { // empty spec
@@ -96,6 +97,9 @@ public class CustomResourceWatcher<T extends EntityInfo> extends AbstractWatcher
         }
         if (infoSpec.getName() == null) {
             infoSpec.setName(name);
+        }
+        if (infoSpec.getNamespace() == null) {
+            infoSpec.setNamespace(namespace);
         }
         return infoSpec;
     }

--- a/src/main/java/io/radanalytics/operator/common/EntityInfo.java
+++ b/src/main/java/io/radanalytics/operator/common/EntityInfo.java
@@ -13,6 +13,7 @@ import java.util.Objects;
  */
 public abstract class EntityInfo {
     protected String name;
+    protected String namespace;
 
     public void setName(String name) {
         this.name = name;
@@ -22,16 +23,24 @@ public abstract class EntityInfo {
         return name;
     }
 
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EntityInfo that = (EntityInfo) o;
-        return Objects.equals(name, that.name);
+        return Objects.equals(name, that.name) && Objects.equals(namespace, that.namespace);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name);
+        return Objects.hash(name, namespace);
     }
 }


### PR DESCRIPTION
where the resource was created.

<!-- Provide a general summary of your changes in the Title above -->


## Description
When using the operator in `WATCH_NAMESPACE=*` the full reconciliation method in the concrete operator can be pain to implement, because one would have to keep track in which namespace the resource had been created on their own in memory (and in case of operator crash, it would be lost). The `getDesiredSet` will now return the `Set<T>`, where the `T` will also contain the `namespace` field.

Thanks to @blublinsky


## Related Issue
issue #39


## Types of changes

- New feature (non-breaking change which adds functionality)
