### PR TITLE
Fix initCrds() on openshift 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>io.radanalytics</groupId>
         <artifactId>operator-parent-pom</artifactId>
-        <version>0.3.17</version>
+        <version>0.3.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.radanalytics</groupId>

--- a/src/main/java/io/radanalytics/operator/common/crd/CrdDeployer.java
+++ b/src/main/java/io/radanalytics/operator/common/crd/CrdDeployer.java
@@ -1,5 +1,6 @@
 package io.radanalytics.operator.common.crd;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionFluent;
@@ -7,6 +8,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.JSONSchemaProps;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import io.radanalytics.operator.common.EntityInfo;
 import io.radanalytics.operator.common.JSONSchemaReader;
 import org.slf4j.Logger;
@@ -30,6 +32,7 @@ public class CrdDeployer {
         final String newPrefix = prefix.substring(0, prefix.length() - 1);
         CustomResourceDefinition crdToReturn;
 
+        Serialization.jsonMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         List<CustomResourceDefinition> crds = client.customResourceDefinitions()
                 .list()
                 .getItems()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Description
* Ignore the unknown fields during the deserialization of the  `CustomResourceDefinition` schema when deploying the operator on OpenShift 4.1
* bump parent to 0.3.19 (new k8s client)

## Related Issue
Fix #45 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in one box that applies: -->

- [x] Bug fix (non-breaking change which fixes an issue)