### PR TITLE
Add a status block to all CRDs created by AbstractOperator

### DIFF
--- a/src/main/java/io/radanalytics/operator/common/crd/CrdDeployer.java
+++ b/src/main/java/io/radanalytics/operator/common/crd/CrdDeployer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionFluent;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceSubresourceStatus;
 import io.fabric8.kubernetes.api.model.apiextensions.JSONSchemaProps;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -143,6 +144,8 @@ public class CrdDeployer {
                     .withShortNames(Arrays.asList(shortNamesLower)).endNames()
                 .withGroup(prefix)
                 .withVersion("v1")
-                .withScope("Namespaced");
+                .withScope("Namespaced")
+                // add an empty status block to all CRDs created
+                .withNewSubresources().withStatus(new CustomResourceSubresourceStatus()).endSubresources();
     }
 }

--- a/src/main/java/io/radanalytics/operator/common/crd/InfoClass.java
+++ b/src/main/java/io/radanalytics/operator/common/crd/InfoClass.java
@@ -4,6 +4,19 @@ import io.fabric8.kubernetes.client.CustomResource;
 
 public class InfoClass<U> extends CustomResource {
     private U spec;
+    private InfoStatus status;
+
+    public InfoClass() {
+        this.status = new InfoStatus();
+    }
+
+    public InfoStatus getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(InfoStatus status) {
+        this.status = status;
+    }
 
     public U getSpec() {
         return spec;

--- a/src/main/java/io/radanalytics/operator/common/crd/InfoStatus.java
+++ b/src/main/java/io/radanalytics/operator/common/crd/InfoStatus.java
@@ -1,0 +1,56 @@
+package io.radanalytics.operator.common.crd;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class InfoStatus implements KubernetesResource {
+
+    private String state;
+    private String lastTransitionTime;
+
+    private static String toDateString(Date date) {
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'kk:mm:ss'Z'");
+        df.setTimeZone(TimeZone.getTimeZone( "GMT" ));
+        return df.format(date);
+    }
+
+    public InfoStatus() {
+        super();
+        this.state = "initial";
+        this.lastTransitionTime = toDateString(new Date());
+    }
+    
+    public InfoStatus(String state, Date dt) {
+        super();
+        this.state = state;
+        this.lastTransitionTime = toDateString(dt);
+    }
+
+    public void setState(String s) {
+        this.state = s;
+    }
+
+    public String getState() {
+        return this.state;
+    }
+
+    public void setLastTransitionTime(Date dt) {
+        this.lastTransitionTime = toDateString(dt);
+    }
+
+    public String getLastTransitionTime() {
+        return this.lastTransitionTime;
+    }
+
+    @Override
+    public String toString() {
+        return "InfoStatus{" +
+                " state=" + state +
+                " lastTransitionTime=" + lastTransitionTime +
+                "}";
+    }
+}


### PR DESCRIPTION
This initial PR creates an empty status block in all CRDs
created by the AbstractOperator, regardless of json schema.
Additionally, it adds a simple routine to optionallyupdate the
status block to contain a 'state' string and 'lastTransitionTime'
but is API compatible with earlier versions of AstractOperator.

In the future, more general support for definable status blocks
can be added.

<!-- Provide a general summary of your changes in the Title above -->


## Description
<!-- Describe your changes in detail -->


## Related Issue
<!-- Reference the related issue by using Issue #42 syntax of use the Fix #42 in one of the commits -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in one box that applies: -->

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
