### PR TITLE
Bump operator-parent-pom version to 0.3.27-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>io.radanalytics</groupId>
     <artifactId>operator-parent-pom</artifactId>
-    <version>0.3.25</version>
+    <version>0.3.27-SNAPSHOT</version>
   </parent>
   <groupId>io.radanalytics</groupId>
   <artifactId>abstract-operator</artifactId>
-  <version>0.6.16-SNAPSHOT</version>
+  <version>0.6.17-SNAPSHOT</version>
   <scm>
     <connection>scm:git:git@github.com:jvm-operators/abstract-operator.git</connection>
     <developerConnection>scm:git:git@github.com:jvm-operators/abstract-operator.git</developerConnection>


### PR DESCRIPTION
## Description

The 4.7.1 fabric8 client appears to break with serialization errors on processing a CRD list response from the kube api server for kubernetes 1.19.  The newer client version fixes it.


## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case / Automation (non-breaking change)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
