### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ script:
 #  script: make build-travis && ./mvnw -s ./.travis/settings.xml clean deploy
 after_success:
   - ./.travis/.travis.release.jars.sh
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.